### PR TITLE
Recommend Scylla Docker image if OS is not supported

### DIFF
--- a/server
+++ b/server
@@ -43,7 +43,7 @@ check_os() {
 
   case "$OS" in
     Linux)   ;;
-    *)        echo "Operating system $OS is not supported by this installer." && exit 1 ;;
+    *)        echo -e "Your operating system $OS is not supported by this installer.\n\nPlease consider using Docker to run Scylla on this machine:\n\nhttps://hub.docker.com/r/scylladb/scylla" && exit 1 ;;
   esac
 }
 


### PR DESCRIPTION
If an user runs the script on an unsupported OS such as macOS or
Windows, point them to the Docker image.

Example output:

  % curl get.scylladb.com/server | bash

  Your operating system Darwin is not supported by this installer.

  Please consider using Docker to run Scylla on this machine:

  https://hub.docker.com/r/scylladb/scylla

Fixes #4