### PR TITLE
Add support for Scylla Enterprise installation

### DIFF
--- a/server
+++ b/server
@@ -188,7 +188,12 @@ require_cmd() {
 
 install_rpm() {
   SCYLLA_RPM_URL="http://downloads.scylladb.com/rpm/centos/scylla-$SCYLLA_RELEASE.repo"
-  run_cmd curl -s -L -o /etc/yum.repos.d/scylla.repo "$SCYLLA_RPM_URL"
+  ret=0
+  run_cmd curl -f -s -L -o /etc/yum.repos.d/scylla.repo "$SCYLLA_RPM_URL" || ret=$?
+  if [ $ret -ne 0 ]; then
+    echo "Your OS is not supported by this installer because there is no package repository."
+    exit 1
+  fi
   run_cmd yum install --assumeyes --quiet "$SCYLLA_PRODUCT-$SCYLLA_VERSION"
 }
 
@@ -296,13 +301,18 @@ debian_install() {
     echo "Debian $VERSION_ID is not supported by this installer."
     exit 1
   fi
-  echo_msg "Installing Scylla version $SCYLLA_VERSION for Debian ..."
   export DEBIAN_FRONTEND=noninteractive
   run_cmd apt update
   run_cmd apt-get install -qq apt-transport-https curl gnupg2 dirmngr
-  run_cmd apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 5e08fbd8b5d6ec9c
+  ret=0
   SCYLLA_DEBIAN_URL="http://downloads.scylladb.com/deb/debian/scylla-$SCYLLA_RELEASE-$VERSION_CODENAME.list"
-  run_cmd curl -s -L -o /etc/apt/sources.list.d/scylla.list "$SCYLLA_DEBIAN_URL"
+  run_cmd curl -f -s -L -o /etc/apt/sources.list.d/scylla.list "$SCYLLA_DEBIAN_URL" || ret=$?
+  if [ $ret -ne 0 ]; then
+    echo "Your OS is not supported by this installer because there is no package repository."
+    exit 1
+  fi
+  echo_msg "Installing Scylla version $SCYLLA_VERSION for Debian ..."
+  run_cmd apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 5e08fbd8b5d6ec9c
   run_cmd apt update
   run_cmd apt-get install -qq "$SCYLLA_PRODUCT=$SCYLLA_VERSION*"
 }
@@ -323,17 +333,22 @@ ubuntu_install() {
     echo "Ubuntu $VERSION_ID is not supported by this installer."
     exit 1
   fi
+  export DEBIAN_FRONTEND=noninteractive
   run_cmd apt update
   if [ "$VERSION_ID" = "16.04" ]; then
     run_cmd apt-get install -qq curl gnupg2 apt-transport-https
   else
     run_cmd apt-get install -qq curl gnupg2
   fi
-  echo_msg "Installing Scylla version $SCYLLA_VERSION for Ubuntu ..."
-  export DEBIAN_FRONTEND=noninteractive
-  run_cmd apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 5e08fbd8b5d6ec9c
   SCYLLA_UBUNTU_URL="http://downloads.scylladb.com/deb/ubuntu/scylla-$SCYLLA_RELEASE-$VERSION_CODENAME.list"
-  run_cmd curl -s -L -o /etc/apt/sources.list.d/scylla.list "$SCYLLA_UBUNTU_URL"
+  ret=0
+  run_cmd curl -f -s -L -o /etc/apt/sources.list.d/scylla.list "$SCYLLA_UBUNTU_URL" || ret=$?
+  if [ $ret -ne 0 ]; then
+    echo "Your OS is not supported by this installer because there is no package repository."
+    exit 1
+  fi
+  echo_msg "Installing Scylla version $SCYLLA_VERSION for Ubuntu ..."
+  run_cmd apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 5e08fbd8b5d6ec9c
   run_cmd apt update
   run_cmd apt-get install -qq "$SCYLLA_PRODUCT=$SCYLLA_VERSION*"
 }


### PR DESCRIPTION
This pull request adds a `--scylla-product` option to the installer, 
which allows users to install Scylla Enterprise.

Fixes #3