### PR TITLE
Enable more URLs and debug options

### DIFF
--- a/server
+++ b/server
@@ -196,12 +196,13 @@ main() {
     esac
   done
 
+  RETRY_OPTION="-o Acquire::Retries=3"
   if [ $VERBOSE -eq 1 ]; then
     YUM_QUIET_CMD_PARAM="--assumeyes"
-    APT_FLAGS="--assume-yes"
+    APT_FLAGS="--assume-yes $RETRY_OPTION"
   else
     YUM_QUIET_CMD_PARAM="--assumeyes --quiet"
-    APT_FLAGS="-qq"
+    APT_FLAGS="-qq $RETRY_OPTION"
   fi
 
   check_product


### PR DESCRIPTION
- Enable installing also latest-nightly repos (for the brave) Fixes #11 
- Enable installing testing repos (debug) - Parameter should give the base URL.
- Add a --verbose option so installation will run with no --quite / -qq, and will use testing repo.
- 2 script function reorg: split, and a new function to get the URLs: As we now want to enable this script to install also:
latest nightly repo
testing repo (to debug scripts)
Let's have a function to set the appropriate URLs and installation params.
- Add retry option, to avoid sporadic failures to get packages.

Also 2 commits Fixes #14 
- Enable all 8* and 7* versions for Oracle linux and RHEL.
- Don't install EPEL on Oracle, Amazon linux and RHEL on debug runs (looks like they are not available for the slim/minimal dockers we use).