### PR TITLE
set_gpg_key: fix condition to match either `master` or `enterprise`

### DIFF
--- a/server
+++ b/server
@@ -119,7 +119,7 @@ query_default_version() {
 
 set_gpg_key() {
   SCYLLA_RELEASE=$(echo $SCYLLA_VERSION | cut -d'-' -f 2)
-  if [ $SCYLLA_RELEASE == *"master"* ] || [ $SCYLLA_RELEASE == *"enterprise"* ]; then
+  if [ $SCYLLA_RELEASE == "master" ] || [ $SCYLLA_RELEASE == "enterprise" ]; then
     SCYLLA_GPG_KEY="d0a112e067426ab2"
   else
     SCYLLA_GPG_KEY="5e08fbd8b5d6ec9c"


### PR DESCRIPTION
During unified-deb (master), we got the following erorr:
```
+ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 5e08fbd8b5d6ec9c
Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.yYVu1JIGiK/gpg.1.sh --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 5e08fbd8b5d6ec9c
gpg: key 5E08FBD8B5D6EC9C: public key "ScyllaDB Package Signing Key 2020 <security@scylladb.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
+ run_cmd apt update
+ CMD=("$@")
+ '[' 0 -eq 0 ']'
+ apt update

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Hit:1 http://security.debian.org/debian-security buster/updates InRelease
Hit:2 http://deb.debian.org/debian buster InRelease
Hit:3 http://deb.debian.org/debian buster-updates InRelease
Get:4 http://downloads.scylladb.com/unstable/scylla/master/deb/unified/2022-01-13T04:03:22Z/scylladb-master stable InRelease [7550 B]
Err:4 http://downloads.scylladb.com/unstable/scylla/master/deb/unified/2022-01-13T04:03:22Z/scylladb-master stable InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY D0A112E067426AB2
```

Looks like we are using the worng key for master,
fixing it