### PR TITLE
server: add support to run on ARM arch

### DIFF
--- a/server
+++ b/server
@@ -57,7 +57,7 @@ shopt -s extglob
 check_arch() {
   ARCH=$(uname -m)
 
-  if [[ "$ARCH" != "x86_64" ]]; then
+  if [[ "$ARCH" != @("x86_64"|"aarch64") ]]; then
     echo "Architecture $ARCH is not supported by this installer."
     exit 1
   fi


### PR DESCRIPTION
Since we are about to use scylla-web-install as a generic way to install
Scylla, we need to add ARM support