### PR TITLE
update versions in ci tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         version:
-         - 4.5.0
          - 4.6.0
+         - 5.0.0
          - 2021.1.0
+         - 2022.1.0
         include:
           - version: 2021.1.0
+            product: --scylla-product scylla-enterprise
+          - version: 2022.1.0
             product: --scylla-product scylla-enterprise
         container:
           - ubuntu:18.04


### PR DESCRIPTION
4.5.0 was removed. web installation for 5.0.0 and 2022.1.0 were added.