### PR TITLE
change grep command in getting FULL_SCYLLA_VERSION

### DIFF
--- a/server
+++ b/server
@@ -193,7 +193,7 @@ setup_install() {
 get_full_version() {
   PATCH_VERSION=$(echo $SCYLLA_VERSION | awk -v FS='.' '{print $3}')
  if [ -n "$PATCH_VERSION" ] && [ -z "$DEFAULT_SCYLLA_VERSION" ] || [[ $SCYLLA_VERSION == *rc* ]]; then
-    FULL_SCYLLA_VERSION=$(apt-cache madison ${SCYLLA_PRODUCT} | grep $SCYLLA_VERSION | cut -d'|' -f 2 | sed 's/[[:space:]]//g')
+    FULL_SCYLLA_VERSION=$(apt-cache madison ${SCYLLA_PRODUCT} | grep -F $SCYLLA_VERSION | cut -d'|' -f 2 | sed 's/[[:space:]]//g')
     if [[ $SCYLLA_PRODUCT =~ "enterprise" ]]; then
       #not including -node-exporter dependency for scylla-enterprise version
       SCYLLA_PRODUCT_VERSION="${SCYLLA_PRODUCT}{,-server,-jmx,-tools,-tools-core,-kernel-conf,-conf,-python3}=$FULL_SCYLLA_VERSION"

--- a/server
+++ b/server
@@ -194,7 +194,7 @@ get_full_version() {
   PATCH_VERSION=$(echo $SCYLLA_VERSION | awk -v FS='.' '{print $3}')
  if [ -n "$PATCH_VERSION" ] && [ -z "$DEFAULT_SCYLLA_VERSION" ] || [[ $SCYLLA_VERSION == *rc* ]]; then
     FULL_SCYLLA_VERSION=$(apt-cache madison ${SCYLLA_PRODUCT} | grep -F $SCYLLA_VERSION | cut -d'|' -f 2 | sed 's/[[:space:]]//g')
-    if [[ $SCYLLA_PRODUCT =~ "enterprise" ]]; then
+    if [[ $SCYLLA_PRODUCT =~ "enterprise" ]] && (( ${SCYLLA_VERSION%%.*} < 2022 )); then
       #not including -node-exporter dependency for scylla-enterprise version
       SCYLLA_PRODUCT_VERSION="${SCYLLA_PRODUCT}{,-server,-jmx,-tools,-tools-core,-kernel-conf,-conf,-python3}=$FULL_SCYLLA_VERSION"
     else


### PR DESCRIPTION
commit: **fd9f6ee**
changes in grep command to get a "fixed" string instead of a regular expression pattern - fix for:
root@701da59c56cc:/scylla-web-install# apt-cache madison scylla | grep 5.0.2
    scylla | **5.0.2**-0.20220807.299122e78-1 | http://downloads.scylladb.com/downloads/scylla/deb/debian-ubuntu/scylladb-5.0 stable/main amd64 Packages
    scylla | 5.0~rc**5-0.2**0220515.9da666e77-1 | http://downloads.scylladb.com/downloads/scylla/deb/debian-ubuntu/scylladb-5.0 stable/main amd64 Packages

commit : **7865d9a**
node-exporter dependency package was added to the scylla-enterprise installation started from version 2022.X