### PR TITLE
server: add Retries when running `apt-get update`

### DIFF
--- a/server
+++ b/server
@@ -494,7 +494,7 @@ deb_install() {
     echo_msg "Installing Scylla version $SCYLLA_VERSION for $NAME ..."
     run_cmd apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $SCYLLA_GPG_KEY
     run_cmd mkdir -p $APT_KEYS_DIR && gpg --homedir /tmp --no-default-keyring --keyring $APT_KEYS_DIR/scylladb.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $SCYLLA_GPG_KEY
-    run_cmd apt update
+    run_cmd apt update $APT_FLAGS
     get_full_version
     run_cmd apt-get install $APT_FLAGS $SCYLLA_PRODUCT_VERSION
   fi


### PR DESCRIPTION
During debug session noticed the following error:
```
[2022-11-06T08:49:29.493Z] E: Failed to fetch http://deb.debian.org/debian/pool/main/p/perl/perl-modules-5.28_5.28.1-6+deb10u1_all.deb  Cannot initiate the connection to deb.debian.org:80 (2a04:4e42:62::644). - connect (101: Network is unreachable) Could not connect to deb.debian.org:80 (199.232.138.132), connection timed out
.
.
.
[2022-11-06T08:49:29.500Z] E: Failed to fetch http://deb.debian.org/debian/pool/main/x/xdg-user-dirs/xdg-user-dirs_0.17-2_amd64.deb  Cannot initiate the connection to deb.debian.org:80 (2a04:4e42:62::644). - connect (101: Network is unreachable)

[2022-11-06T08:49:29.500Z] E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Re-build is working. let's retry `apt-get update` to try to overcome this issue