### PR TITLE
gpg: add the 2024 pub key

### DIFF
--- a/server
+++ b/server
@@ -146,7 +146,7 @@ set_gpg_key() {
       SCYLLA_GPG_KEY="5e08fbd8b5d6ec9c"
       ;;
     *)
-      SCYLLA_GPG_KEY="d0a112e067426ab2"
+      SCYLLA_GPG_KEY="d0a112e067426ab2 491c93b9de7496a7"
       ;;
   esac
 }


### PR DESCRIPTION
The 2022 key remains for the period of time between the addition of the new pub key and the time we start singing with the 2024 key, later we can remove it.