### PR TITLE
web-install: add ubuntu24.04 support

### DIFF
--- a/server
+++ b/server
@@ -406,7 +406,7 @@ check_debian_ubuntu_version() {
     esac
   elif [[ "$ID" == "ubuntu" ]]; then
     case "$VERSION_ID" in
-      "16.04"|"18.04"|"20.04"|"22.04")
+      "16.04"|"18.04"|"20.04"|"22.04"|"24.04")
         return 0
         ;;
       *)


### PR DESCRIPTION

Fixes: https://github.com/scylladb/scylladb-web-install/issues/64