### PR TITLE
server: fix rhel8 support

### DIFF
--- a/server
+++ b/server
@@ -353,7 +353,7 @@ fedora_install() {
 
 check_rhel_version() {
   case "$VERSION_ID" in
-    7.?|8.?)
+    7.?|8.?*)
       return 1
       ;;
     *)


### PR DESCRIPTION
During 6.0 i saw the following faliure:
```
[2024-05-23T08:34:29.061Z] Red Hat Enterprise Linux 8.10 is not supported by this installer.

[2024-05-23T08:34:29.061Z] Error: building at STEP "RUN ./server.sh $SCYLLA_PRODUCT_NAME $SCYLLA_VERSION $DRY_RUN $SCYLLA_REPO_FILE_URL": while running runtime: exit status 1
```

Failed on both release and debug,

Fixing it