### PR TITLE
server: fix Oracle Linux 8.10 support

### DIFF
--- a/server
+++ b/server
@@ -353,7 +353,7 @@ fedora_install() {
 
 check_rhel_version() {
   case "$VERSION_ID" in
-    7.?|8.?*)
+    7.?|8*)
       return 1
       ;;
     *)
@@ -374,7 +374,7 @@ rhel_install() {
 
 check_ol_version() {
   case "$VERSION_ID" in
-    7.?|8.?)
+    7.?|8*)
       return 1
       ;;
     *)


### PR DESCRIPTION
fix error:
```
01:20:37  Oracle Linux 8.10 is not supported by this installer.
01:20:37  Error: building at STEP "RUN ./server.sh $SCYLLA_PRODUCT_NAME $SCYLLA_VERSION $DRY_RUN $SCYLLA_REPO_FILE_URL": while running runtime: exit status 1
```

Failed jobs:
jenkins.scylladb.com/job/scylla-master/job/centos-rpm/1399/
https://jenkins.scylladb.com/job/scylla-6.0/job/centos-rpm/5/