### PR TITLE
web-install: remove EOL OS + align release versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         version:
-         - 5.2.0
          - 5.4.0
-         - 2022.1.0
-         - 2022.2.0
+         - 6.0.0
          - 2023.1.0
          - 2024.1.0
         include:
-          - version: 2022.1.0
-            product: --scylla-product scylla-enterprise
-          - version: 2022.2.0
-            product: --scylla-product scylla-enterprise
           - version: 2023.1.0
             product: --scylla-product scylla-enterprise
           - version: 2024.1.0
@@ -30,34 +24,43 @@ jobs:
         container:
           - ubuntu:20.04
           - ubuntu:22.04
-          - debian:10
           - debian:11
           - rockylinux:8
-          - centos:7
+          - rockylinux:9
           - oraclelinux:8
-          - public.ecr.aws/amazonlinux/amazonlinux:2
     steps:
       - if: contains(matrix.container, 'ubuntu') || contains(matrix.container, 'debian')
         name: Install packages Ubuntu / Debian
         run: | 
-          apt-get update && apt-get install -y curl
+          apt-get update
 
-      - if: contains(matrix.container, 'centos') || contains(matrix.container, 'amazon') || contains(matrix.container, 'oracle') || contains(matrix.container, 'rockylinux')
-        name: Install packages For Centos / Amazonlinux / Rockylinux / Oracle
+      - if: contains(matrix.container, 'centos') || contains(matrix.container, 'oracle') || (contains(matrix.container, 'rockylinux:9') && matrix.version != '2023.1.0')
+        name: Install packages For Centos / Rockylinux / Oracle
         run: |
-          yum update -y && yum install -y curl tar gzip
+          yum update -y && yum install -y tar gzip
 
       - uses: actions/checkout@v2
 
       - name: Install Scylla first release
+        if: |
+          !(contains(matrix.container, 'rockylinux:9') && matrix.version == '2023.1.0')
         run: ./server --scylla-version ${{ matrix.version }} ${{ matrix.product }}
+
+  test_amazon_linux:
+    name: Test installation for amazonlinux:2023 in version 6.0.0 only
+    runs-on: ubuntu-latest
+    container: amazonlinux:2023
+    steps:
+      - run: yum update -y && yum install -y tar gzip
+      - uses: actions/checkout@v2
+      - run: ./server --scylla-version 6.0.0
 
   test_latest_in_version:
     name: Test installation for latest in specific version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: sudo ./server --scylla-version 5.4
+      - run: sudo ./server --scylla-version 6.0
 
   test_nightly_master:
     name: Test installation for nightly-master version

--- a/README.md
+++ b/README.md
@@ -22,22 +22,23 @@ In `<version>`, specify `(x.y)` version to install the latest patch for this ver
 - `[--dry-run]` prints only the commands and the installation flow without actually installing it, useful for verification.
 
 #### Examples:
-Installing ScyllaDB Open Source version 5.2.10:
+Installing ScyllaDB Open Source version 5.4.8:
 ```shell
-curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version 5.2.10
+curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version 5.4.8
 ```
-Installing ScyllaDB Enterprise latest patch of version 2023.1:
+Installing ScyllaDB Enterprise latest patch of version 2024.1:
 ```shell
-curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-product scylla-enterprise --scylla-version 2023.1
+curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-product scylla-enterprise --scylla-version 2024.1
 ```
-Running an installation of nightly version 5.4 in dry-run:
+Running an installation of nightly version 6.0 in dry-run:
 ```shell
-curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version nightly-5.4 --dry-run
+curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version nightly-6.0 --dry-run
 ```
 
 ## Supported OSs by Platform and Version
-Ensure that your platform is supported by the ScyllaDB version you want to install.
-See [OS Support by Platform and Version](https://opensource.docs.scylladb.com/stable/getting-started/os-support.html).
+Ensure your platform is supported by ScyllaDB version you want to install.
+* For ScyllaDB Open Source - see [OS Support by Platform and Version for OSS](https://opensource.docs.scylladb.com/stable/getting-started/os-support.html).
+* For ScyllaDB Enterprise - see [OS Support by Platform and Version for Enterprise](https://enterprise.docs.scylladb.com/stable/getting-started/os-support.html).
 
 ## Contributing
 We welcome public/internal contributions into this repository via pull requests.  

--- a/server
+++ b/server
@@ -54,11 +54,17 @@ check_product() {
 
 is_supported_version() {
   if [[ -n "$SCYLLA_VERSION" ]] && [[ $SCYLLA_VERSION != *"nightly"* ]]; then
-    if [[ "$SCYLLA_VERSION" != @(2022.[1-2]*|202[3-9].*|5.[2,4-9]*|[6-9].*) ]]; then
-      echo "The specified scylla-version $SCYLLA_VERSION has reached End of Life (EOL) and is no longer supported. For supported ScyllaDB versions please refer to https://docs.scylladb.com/getting-started/os-support"
+    if [[ "$SCYLLA_VERSION" != @(202[3-9].*|5.[4-9]*|[6-9].*) ]]; then
+      supported_versions_message
       exit 1
     fi
   fi
+}
+
+supported_versions_message() {
+  echo "The specified scylla-version '$SCYLLA_VERSION' has reached End of Life (EOL) or not available.
+  • For OSS supported ScyllaDB versions please refer to https://docs.scylladb.com/stable/getting-started/os-support
+  • For Enterprise supported ScyllaDB versions please refer to https://enterprise.docs.scylladb.com/stable/getting-started/os-support"
 }
 
 is_rc_version() {
@@ -297,7 +303,7 @@ install_rpm() {
   ret=0
   run_cmd curl -f -s -L -o /etc/yum.repos.d/scylla.repo "$SCYLLA_URL" || ret=$?
   if [ $ret -ne 0 ]; then
-    echo "There is no package repository for version '$SCYLLA_VERSION'. For ScyllaDB versions please refer to https://docs.scylladb.com/getting-started/os-support"
+    supported_versions_message
     exit 1
   fi
   run_cmd $RPM_INSTALL_TOOL install $YUM_QUIET_CMD_PARAM $SCYLLA_PRODUCT_VERSION
@@ -305,7 +311,7 @@ install_rpm() {
 
 check_amzn_version() {
   case "$VERSION_ID" in
-    "2")
+    2*)
       return 1
       ;;
     *)
@@ -326,7 +332,7 @@ amzn_install() {
 
 check_centos_version() {
   case "$VERSION_ID" in
-    7*|8*|9*)
+    8*|9*)
       return 1
       ;;
     *)
@@ -406,7 +412,7 @@ check_debian_ubuntu_version() {
     esac
   elif [[ "$ID" == "ubuntu" ]]; then
     case "$VERSION_ID" in
-      "16.04"|"18.04"|"20.04"|"22.04"|"24.04")
+      "20.04"|"22.04"|"24.04")
         return 0
         ;;
       *)
@@ -425,7 +431,7 @@ deb_install() {
     ret=0
     run_cmd curl -f -s -L -o /etc/apt/sources.list.d/scylla.list "$SCYLLA_URL" || ret=$?
     if [ $ret -ne 0 ]; then
-      echo "There is no package repository for version '$SCYLLA_VERSION'. For ScyllaDB versions please refer to https://docs.scylladb.com/getting-started/os-support"
+      supported_versions_message
       exit 1
     fi
     echo_msg "Installing Scylla version $SCYLLA_VERSION for $NAME ..."


### PR DESCRIPTION
includes the following changes:
1) as `debian10` and `centos7` reached EOL, removing it
2) align releases version (5.2.0, 2022.1, 2022.2 - removed / 6.0.0 - added)
3) adding `rockylinux:9` support (skip only in case 2023.1)
4) removing installation of `curl` package in test.yaml as for
   debian/ubuntu it is part of the server script and for rpm it is part of minimal image
5) test.yml - Install packages and Scylla for `amazonlinux:2023` for only current supported version `6.0.0`
6) update `README.md` file accordingly