### PR TITLE
gpg: add the 2024 pub key (RSA)

### DIFF
--- a/server
+++ b/server
@@ -87,7 +87,7 @@ packages_update() {
 }
 
 setup_install() {
-  SCYLLA_GPG_KEY="d0a112e067426ab2 491c93b9de7496a7"
+  SCYLLA_GPG_KEY="d0a112e067426ab2 491c93b9de7496a7 a43e06657bac99e3"
   if [[ -n "$SCYLLA_REPO_FILE_URL" ]]; then
     SCYLLA_URL=${SCYLLA_REPO_FILE_URL}
     SCYLLA_PRODUCT_VERSION="${SCYLLA_PRODUCT}"


### PR DESCRIPTION
Adding a new GPG key in RSA format which supports both deb and rpm signing

Related to scylladb/scylla-enterprise#4222