### PR TITLE
test.yml: adding 2024.2.0 to ci web-install tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,13 @@ jobs:
          - 6.1.0
          - 2023.1.0
          - 2024.1.0
+         - 2024.2.0
         include:
           - version: 2023.1.0
             product: --scylla-product scylla-enterprise
           - version: 2024.1.0
+            product: --scylla-product scylla-enterprise
+          - version: 2024.2.0
             product: --scylla-product scylla-enterprise
         container:
           - ubuntu:20.04


### PR DESCRIPTION
as first GA of 2024.2.0 already released.
adding this version to test.yml to run ci tests on this version as well