### PR TITLE
server: add support for `almalinux` installation and adjust tests to match latest releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         version:
-         - 5.4.0
-         - 6.0.0
-         - 6.1.0
-         - 2023.1.0
+         - 6.2.0
          - 2024.1.0
          - 2024.2.0
+         - 2025.1.0
         include:
-          - version: 2023.1.0
-            product: --scylla-product scylla-enterprise
           - version: 2024.1.0
             product: --scylla-product scylla-enterprise
           - version: 2024.2.0
@@ -33,45 +29,31 @@ jobs:
           - rockylinux:8
           - rockylinux:9
           - oraclelinux:8
+          - almalinux:9
+          - amazonlinux:2023
     steps:
       - if: contains(matrix.container, 'ubuntu') || contains(matrix.container, 'debian')
         name: Install packages Ubuntu / Debian
         run: | 
           apt-get update
 
-      - if: contains(matrix.container, 'centos') || contains(matrix.container, 'oracle') || (contains(matrix.container, 'rockylinux:9') && matrix.version != '2023.1.0')
-        name: Install packages For Centos / Rockylinux / Oracle
+      - if: contains(matrix.container, 'amazonlinux') || contains(matrix.container, 'oracle') || (contains(matrix.container, 'rockylinux'))
+        name: Install packages For AmazonLinux / Rockylinux / Oracle
         run: |
           yum update -y && yum install -y tar gzip
 
       - uses: actions/checkout@v4
 
-      - name: Install Scylla first release
-        if: |
-          !(contains(matrix.container, 'rockylinux:9') && matrix.version == '2023.1.0' || contains(matrix.container, 'ubuntu:24.04') && matrix.version == '2023.1.0')
+      - if: ${{ !(matrix.container == 'amazonlinux:2023' && matrix.version == '2024.1.0') }}
+        name: Install Scylla first release
         run: ./server --scylla-version ${{ matrix.version }} ${{ matrix.product }}
-
-  test_amazon_linux:
-    name: Test installation on amazonlinux:2023 with ${{ matrix.version }}
-    runs-on: ubuntu-latest
-    container: amazonlinux:2023
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - 6.0.0
-          - 6.1.0
-    steps:
-      - run: yum update -y && yum install -y tar gzip
-      - uses: actions/checkout@v4
-      - run: ./server --scylla-version ${{ matrix.version }}
 
   test_latest_in_version:
     name: Test installation for latest in specific version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: sudo ./server --scylla-version 6.1
+      - run: sudo ./server --scylla-version 2025.1
 
   test_nightly_master:
     name: Test installation for nightly-master version

--- a/server
+++ b/server
@@ -137,9 +137,9 @@ get_full_version() {
   PATCH_VERSION=$(echo $SCYLLA_VERSION | awk -v FS='.' '{print $3}')
   if [ -n "$PATCH_VERSION" ] && [ -z "$DEFAULT_SCYLLA_VERSION" ] || [[ $SCYLLA_VERSION == *rc* ]]; then
     FULL_SCYLLA_VERSION=$(apt-cache madison ${SCYLLA_PRODUCT} | grep -F -w $SCYLLA_VERSION | cut -d'|' -f 2 | sed 's/[[:space:]]//g' | head -n1)
-    PACKAGES_LIST=',-server,-jmx,-tools,-tools-core,-kernel-conf,-node-exporter,-conf,-python3'
-    if ([[ $SCYLLA_PRODUCT =~ "scylla" ]] && [[ ${SCYLLA_VERSION%.*} > "5.2" ]]) || ([[ $SCYLLA_PRODUCT =~ "enterprise" ]] && [[ ${SCYLLA_VERSION%%.*} > "2023" ]]); then
-      PACKAGES_LIST="${PACKAGES_LIST},-cqlsh"
+    PACKAGES_LIST=',-server,-cqlsh,-tools,-tools-core,-kernel-conf,-node-exporter,-conf,-python3'
+    if ([[ $SCYLLA_PRODUCT =~ "enterprise" ]] && [[ ${SCYLLA_VERSION} =~ "2024.1" ]]); then
+      PACKAGES_LIST="${PACKAGES_LIST},-jmx"
     fi
     SCYLLA_PRODUCT_VERSION="${SCYLLA_PRODUCT}{$PACKAGES_LIST}=$FULL_SCYLLA_VERSION"
   fi
@@ -242,6 +242,7 @@ main() {
     "centos"|"rocky") centos_install ;;
     "debian"|"ubuntu") deb_install ;;
     "fedora") fedora_install ;;
+    "almalinux") centos_install ;;
     "ol") ol_install ;;
     "rhel") rhel_install ;;
     *) echo "Operating system '$ID' is not supported by this installer." && exit 1


### PR DESCRIPTION
As it's 1:1 binary-compatible with RHEL 9 and CentOS Stream 9

Also, fixing the unit tests to match the updated releases we have and
support

Fixes: https://github.com/scylladb/scylladb/issues/23583

### Testing (locally)
```
[yaronkaikov@london]~/git/scylla-web-install (main)$ podman run -it --rm -v /home/yaronkaikov/git/scylla-web-install/:/scylla-web-install -w /scylla-web-install almalinux
[root@4b8d253ec742 scylla-web-install]# curl -sSf get.scylladb.com/server | bash
Operating system 'almalinux' is not supported by this installer.
[root@4b8d253ec742 scylla-web-install]# ./server 
Installing Scylla version 2025.1.0 for CentOS ...
Importing GPG key 0x7BAC99E3:
 Userid     : "ScyllaDB Package Signing Key 2024 (RSA) <security@scylladb.com>"
 Fingerprint: 4556 21E3 82DF B3E5 6B0C FBDB A43E 0665 7BAC 99E3
 From       : https://downloads.scylladb.com/downloads/gpg/scylladb-2024-rsa.gpg

Installed:
  kmod-28-10.el9.x86_64                                            scylla-2025.1.0-0.20250325.9dca28d2b818.x86_64                     scylla-conf-2025.1.0-0.20250325.9dca28d2b818.x86_64          scylla-cqlsh-2025.1.0-0.20250325.9dca28d2b818.x86_64       
  scylla-kernel-conf-2025.1.0-0.20250325.9dca28d2b818.x86_64       scylla-node-exporter-2025.1.0-0.20250325.9dca28d2b818.x86_64       scylla-python3-2025.1.0-0.20250325.9dca28d2b818.x86_64       scylla-server-2025.1.0-0.20250325.9dca28d2b818.x86_64      

Scylla installation done!
[root@4b8d253ec742 scylla-web-install]# scylla --version
2025.1.0-0.20250325.9dca28d2b818
```