### PR TITLE
Create update_jira_status_ready_for_merge.yml - Jira status automation

### DIFF
--- a/.github/workflows/update_jira_status_ready_for_merge.yml
+++ b/.github/workflows/update_jira_status_ready_for_merge.yml
@@ -1,0 +1,65 @@
+name: Update Status - Ready For Merge
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  action-jira-status-update-ready-for-merge:
+    if: ${{ github.event.label.name == 'status/merge_candidate' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Extract Jira Ticket IDs
+        id: get-jira
+        run: |
+          echo "Label 'status/merge candidate' detected. Looking for Jira ticket IDs..."
+
+          title="${{ github.event.pull_request.title }}"
+          body="${{ github.event.pull_request.body }}"
+          body="${body:-}"  # default to empty if null
+
+          echo "PR title: $title"
+          echo "PR body: $body"
+
+          > tickets.txt
+
+          # Extract Jira tickets from title
+          echo "$title" | grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
+
+          # Extract all Jira tickets from Fixes lines in body (case-insensitive)
+          echo "$body" | grep -iE '^Fixes[[:space:]]*:[[:space:]]*[A-Z]+-[0-9]+' | \
+          grep -oE '[A-Z]+-[0-9]+' >> tickets.txt || true
+
+          # Deduplicate tickets
+          sort -u tickets.txt > unique_tickets.txt
+
+          if [[ ! -s unique_tickets.txt ]]; then
+            echo "No Jira tickets found in PR title or body. Skipping Jira update."
+            echo "ticket-ids=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          cat unique_tickets.txt
+          tickets_csv=$(paste -sd, unique_tickets.txt)
+          echo "Final Jira ticket list: $tickets_csv"
+          echo "ticket-ids=$tickets_csv" >> $GITHUB_OUTPUT
+
+      - name: Transition Jira Tickets to 'Ready for Merge'
+        if: steps.get-jira.outputs.ticket-ids != ''
+        env:
+          JIRA_AUTH: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+        run: |
+          IFS=',' read -ra tickets <<< "${{ steps.get-jira.outputs.ticket-ids }}"
+          for ticket_id in "${tickets[@]}"; do
+            echo "Transitioning Jira ticket to 'Ready for Merge': $ticket_id"
+            curl --fail -X POST \
+              --url "https://scylladb.atlassian.net/rest/api/3/issue/${ticket_id}/transitions" \
+              --user "$JIRA_AUTH" \
+              --header "Accept: application/json" \
+              --header "Content-Type: application/json" \
+              -d '{"transition": {"id": "131"}}'
+          done


### PR DESCRIPTION
When a PR is added with the 'status/merge_candidate' label, then the relevant Jira ticket status will change to 'Ready For Merge'