### PR TITLE
test.yml: update versions and remove EOL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,19 +7,19 @@ jobs:
   test_supported_versions:
     name: Test on ${{matrix.container }} with ${{ matrix.version }}
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+    container:
+      image: ${{ matrix.container }}
+      options: --privileged
     strategy:
       fail-fast: false
       matrix:
         version:
-         - 6.2.0
          - 2024.1.0
-         - 2024.2.0
          - 2025.1.0
+         - 2025.2.0
+         - 2025.3.0
         include:
           - version: 2024.1.0
-            product: --scylla-product scylla-enterprise
-          - version: 2024.2.0
             product: --scylla-product scylla-enterprise
         container:
           - ubuntu:22.04
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: sudo ./server --scylla-version 2025.1
+      - run: sudo ./server --scylla-version 2025.3
 
   test_nightly_master:
     name: Test installation for nightly-master version

--- a/server
+++ b/server
@@ -137,10 +137,9 @@ get_full_version() {
   PATCH_VERSION=$(echo $SCYLLA_VERSION | awk -v FS='.' '{print $3}')
   if [ -n "$PATCH_VERSION" ] && [ -z "$DEFAULT_SCYLLA_VERSION" ] || [[ $SCYLLA_VERSION == *rc* ]]; then
     FULL_SCYLLA_VERSION=$(apt-cache madison ${SCYLLA_PRODUCT} | grep -F -w $SCYLLA_VERSION | cut -d'|' -f 2 | sed 's/[[:space:]]//g' | head -n1)
-    PACKAGES_LIST=',-server,-cqlsh,-tools,-tools-core,-kernel-conf,-node-exporter,-conf,-python3'
-    if ([[ $SCYLLA_PRODUCT =~ "enterprise" ]] && [[ ${SCYLLA_VERSION} =~ "2024.1" ]]); then
-      PACKAGES_LIST="${PACKAGES_LIST},-jmx"
-    fi
+    PACKAGES_LIST=',-server,-cqlsh,-kernel-conf,-node-exporter,-conf,-python3'
+    [[ "$SCYLLA_VERSION" == 2025.1* ]] && PACKAGES_LIST+=",-tools,-tools-core"
+    [[ "$SCYLLA_VERSION" == 2024.1* ]] && PACKAGES_LIST+=",-tools,-tools-core,-jmx"
     SCYLLA_PRODUCT_VERSION="${SCYLLA_PRODUCT}{$PACKAGES_LIST}=$FULL_SCYLLA_VERSION"
   fi
 }


### PR DESCRIPTION
1) adding versions: `2025.3.0` and `2025.2.0`
2) update installation for latest to 2025.3 - our latest GA 
3) removed EOL versions: `6.2.0` and `2024.2.0`
4) removed `,-tools,-tools-core` packages from 2025.2 and 2025.3 installation
5) adding `--privileged` for container access to fix scylla-kernel-conf installation errors on Debian 11
seen the following error only on Debian 11 container: 
```
error 255 in /opt/scylladb/kernel_conf/post_install.sh line 31
dpkg: error processing package scylla-kernel-conf (--configure):
 installed scylla-kernel-conf package post-installation script subprocess returned error exit status 255
```